### PR TITLE
260721-async-selector-rewrite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,13 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.7",
         "@mui/material": "^7.3.7",
+        "@reduxjs/toolkit": "^2.12.0",
+        "async-selector-kit": "^3.0.2",
         "openai": "^5.12.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-hotkeys-hook": "^5.1.0"
+        "react-hotkeys-hook": "^5.1.0",
+        "react-redux": "^9.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -1501,6 +1504,32 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1788,6 +1817,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1898,6 +1939,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.39.0",
@@ -2255,6 +2302,28 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/async-selector": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/async-selector/-/async-selector-1.0.26.tgz",
+      "integrity": "sha512-jgca9a15/iSVuC9b4WxN4e07bDiJ2rHzDKbde28S/rbfSJ6WMwqrcyPPoshNv5GSwjPHEOnflGo3ekrwTcN2Sw==",
+      "license": "MIT"
+    },
+    "node_modules/async-selector-kit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/async-selector-kit/-/async-selector-kit-3.0.2.tgz",
+      "integrity": "sha512-eyQqPFgh6rXwUj/LZBOCTb1N2pzlrb5vnVzj1NFrToJGLmMzai3dz2rIFiWgu1WwTFv1rm94yLriuvDLFZ0N8A==",
+      "license": "MIT",
+      "dependencies": {
+        "async-selector": "^1.0.24",
+        "reselect": "^4.0.0"
+      }
+    },
+    "node_modules/async-selector-kit/node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
+      "license": "MIT"
     },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
@@ -3021,6 +3090,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "11.1.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
+      "integrity": "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -16142,6 +16221,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -19874,6 +19954,30 @@
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -19899,6 +20003,28 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -20315,6 +20441,15 @@
       "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/vite": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,13 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.7",
     "@mui/material": "^7.3.7",
+    "@reduxjs/toolkit": "^2.12.0",
+    "async-selector-kit": "^3.0.2",
     "openai": "^5.12.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-hotkeys-hook": "^5.1.0"
+    "react-hotkeys-hook": "^5.1.0",
+    "react-redux": "^9.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,51 +1,22 @@
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { Box, Container, Paper, Typography } from "@mui/material";
 import Settings from "./components/Settings";
-import type { TranscriptionModelId } from "./components/Settings/transcriptionModels";
 import TranscriptionEditor from "./components/TranscriptionEditor";
 import RecordingControls from "./components/RecordingControls";
 import TranscriptionActions from "./components/TranscriptionActions";
 import ErrorDisplay from "./components/ErrorDisplay";
 import TranscriptionHistory from "./components/TranscriptionHistory";
-import {
-  saveTranscription,
-  getTranscriptions,
-  deleteTranscription,
-  TranscriptionRecord,
-} from "./utils/transcriptionStorage";
+import { useAppDispatch, useAppSelector } from "./store/hooks";
+import { transcriptionActions } from "./features/transcription/slice/reducers";
+import { selectTranscriptionText } from "./features/transcription/slice/selectors";
 
-function App() {
-  const [transcription, setTranscription] = useState<string>("");
-  const [error, setError] = useState<string>("");
-  const [isCopied, setIsCopied] = useState(false);
-  const [apiKey, setApiKey] = useState<string>("");
-  const [model, setModel] = useState<TranscriptionModelId>("whisper-1");
-  const [transcriptionHistory, setTranscriptionHistory] = useState<
-    TranscriptionRecord[]
-  >([]);
+const App = () => {
+  const dispatch = useAppDispatch();
+  const transcription = useAppSelector(selectTranscriptionText);
 
   useEffect(() => {
-    const history = getTranscriptions();
-    setTranscriptionHistory(history);
-  }, []);
-
-  const handleNewTranscription = (newTranscription: string) => {
-    setTranscription(newTranscription);
-    const savedRecord = saveTranscription(newTranscription);
-    if (savedRecord) {
-      setTranscriptionHistory((prev) => [savedRecord, ...prev]);
-    }
-  };
-
-  const handleDeleteTranscription = (id: string) => {
-    deleteTranscription(id);
-    setTranscriptionHistory((prev) => prev.filter((t) => t.id !== id));
-  };
-
-  const clearTranscription = () => {
-    setTranscription("");
-    setError("");
-  };
+    dispatch(transcriptionActions.hydrateHistory());
+  }, [dispatch]);
 
   return (
     <Box
@@ -65,17 +36,11 @@ function App() {
             gap: 2,
           }}
         >
-          <Settings setApiKey={setApiKey} model={model} setModel={setModel} />
+          <Settings />
 
-          <RecordingControls
-            setTranscription={handleNewTranscription}
-            setError={setError}
-            setIsCopied={setIsCopied}
-            apiKey={apiKey}
-            model={model}
-          />
+          <RecordingControls />
 
-          <ErrorDisplay error={error} setError={setError} />
+          <ErrorDisplay />
 
           {transcription && (
             <Box
@@ -96,28 +61,17 @@ function App() {
                 }}
               >
                 <Typography variant="h6">Transcription</Typography>
-                <TranscriptionActions
-                  transcription={transcription}
-                  onClear={clearTranscription}
-                  isCopied={isCopied}
-                  setIsCopied={setIsCopied}
-                />
+                <TranscriptionActions />
               </Box>
-              <TranscriptionEditor
-                value={transcription}
-                onChange={setTranscription}
-              />
+              <TranscriptionEditor />
             </Box>
           )}
 
-          <TranscriptionHistory
-            transcriptions={transcriptionHistory}
-            onDeleteTranscription={handleDeleteTranscription}
-          />
+          <TranscriptionHistory />
         </Paper>
       </Container>
     </Box>
   );
-}
+};
 
 export default App;

--- a/src/components/ErrorDisplay.tsx
+++ b/src/components/ErrorDisplay.tsx
@@ -1,19 +1,24 @@
 import { Alert, IconButton } from "@mui/material";
 import { Close } from "@mui/icons-material";
+import { useAppDispatch, useAppSelector } from "../store/hooks";
+import { transcriptionActions } from "../features/transcription/slice/reducers";
+import { selectTranscriptionError } from "../features/transcription/slice/selectors";
 
-type Props = {
-  error: string;
-  setError: React.Dispatch<React.SetStateAction<string>>;
-};
+const ErrorDisplay = () => {
+  const dispatch = useAppDispatch();
+  const error = useAppSelector(selectTranscriptionError);
 
-const ErrorDisplay = ({ error, setError }: Props) => {
   if (!error) return null;
 
   return (
     <Alert
       severity="error"
       action={
-        <IconButton size="small" onClick={() => setError("")} title="Close error">
+        <IconButton
+          size="small"
+          onClick={() => dispatch(transcriptionActions.setError(""))}
+          title="Close error"
+        >
           <Close fontSize="small" />
         </IconButton>
       }

--- a/src/components/RecordingControls/HookWrapper.tsx
+++ b/src/components/RecordingControls/HookWrapper.tsx
@@ -1,8 +1,11 @@
 import { useHotkeys } from "react-hotkeys-hook";
+import { useAppSelector } from "../../store/hooks";
+import {
+  selectIsPaused,
+  selectIsRecording,
+} from "../../features/recording/slice/selectors";
 
 type Props = {
-  isRecording: boolean;
-  isPaused: boolean;
   startRecording: () => void;
   stopRecording: () => void;
   pauseRecording: () => void;
@@ -11,15 +14,15 @@ type Props = {
 };
 
 const HookWrapper = ({
-  isRecording,
-  isPaused,
   startRecording,
   stopRecording,
   pauseRecording,
   resumeRecording,
   cancelRecording,
 }: Props) => {
-  // Global hotkey for recording
+  const isRecording = useAppSelector(selectIsRecording);
+  const isPaused = useAppSelector(selectIsPaused);
+
   useHotkeys(
     "ctrl+k",
     (e) => {
@@ -33,7 +36,6 @@ const HookWrapper = ({
     { enableOnFormTags: true }
   );
 
-  // Escape key to cancel recording
   useHotkeys(
     "escape",
     (e) => {
@@ -45,7 +47,6 @@ const HookWrapper = ({
     { enableOnFormTags: true }
   );
 
-  // Spacebar to pause/resume recording
   useHotkeys(
     "space",
     (e) => {

--- a/src/components/RecordingControls/PendingAudioBanner.tsx
+++ b/src/components/RecordingControls/PendingAudioBanner.tsx
@@ -1,0 +1,67 @@
+import { Alert, Button, Stack } from "@mui/material";
+import { Download, Mic, Refresh } from "@mui/icons-material";
+import { useAppSelector } from "../../store/hooks";
+import { PendingSource } from "../../features/recording/slice/reducers";
+import {
+  selectIsUploadPending,
+  selectPendingFileName,
+  selectPendingSource,
+} from "../../features/recording/slice/selectors";
+import { selectTranscribeAudioLoading } from "../../features/transcription/slice/command/transcribeAudio";
+
+type Props = {
+  onDismiss: () => void;
+  onTranscribe: () => void;
+  onDownload: () => void;
+};
+
+const PendingAudioBanner = ({
+  onDismiss,
+  onTranscribe,
+  onDownload,
+}: Props) => {
+  const pendingFileName = useAppSelector(selectPendingFileName);
+  const pendingSource = useAppSelector(selectPendingSource);
+  const isUploadPending = useAppSelector(selectIsUploadPending);
+  const isProcessing = useAppSelector(selectTranscribeAudioLoading);
+  const isUploadSource = pendingSource === PendingSource.Upload;
+
+  const message = isUploadPending
+    ? `Audio ready: ${pendingFileName || "uploaded file"}`
+    : isUploadSource
+      ? `Transcription failed for ${pendingFileName || "uploaded file"}. You can retry or download.`
+      : "Recording saved! The transcription request failed, but your recording is preserved.";
+
+  return (
+    <Alert
+      severity={isUploadPending ? "info" : "warning"}
+      onClose={onDismiss}
+      sx={{ mt: 2 }}
+    >
+      {message}
+      <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={isUploadPending ? <Mic /> : <Refresh />}
+          onClick={onTranscribe}
+          disabled={isProcessing}
+          sx={{ flex: 1 }}
+        >
+          {isUploadPending ? "Transcribe" : "Retry"}
+        </Button>
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<Download />}
+          onClick={onDownload}
+          sx={{ flex: 1 }}
+        >
+          Download
+        </Button>
+      </Stack>
+    </Alert>
+  );
+};
+
+export default PendingAudioBanner;

--- a/src/components/RecordingControls/RecordingTimer.tsx
+++ b/src/components/RecordingControls/RecordingTimer.tsx
@@ -1,13 +1,15 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { Box, Typography } from "@mui/material";
 import { Mic, Pause } from "@mui/icons-material";
+import { useAppSelector } from "../../store/hooks";
+import {
+  selectIsPaused,
+  selectIsRecording,
+} from "../../features/recording/slice/selectors";
 
-type Props = {
-  isRecording: boolean;
-  isPaused: boolean;
-};
-
-const RecordingTimer = ({ isRecording, isPaused }: Props) => {
+const RecordingTimer = () => {
+  const isRecording = useAppSelector(selectIsRecording);
+  const isPaused = useAppSelector(selectIsPaused);
   const [recordingTime, setRecordingTime] = useState(0);
   const recordingStartTimeRef = useRef<number>(0);
   const totalPausedTimeRef = useRef<number>(0);

--- a/src/components/RecordingControls/RecordingToolbar.tsx
+++ b/src/components/RecordingControls/RecordingToolbar.tsx
@@ -1,0 +1,156 @@
+import { Box, IconButton, Stack } from "@mui/material";
+import {
+  FiberManualRecord,
+  PlayArrow,
+  Pause,
+  Cancel,
+  Upload,
+} from "@mui/icons-material";
+import { keyframes } from "@emotion/react";
+import { useAppSelector } from "../../store/hooks";
+import {
+  selectIsPaused,
+  selectIsRecording,
+} from "../../features/recording/slice/selectors";
+import { selectTranscribeAudioLoading } from "../../features/transcription/slice/command/transcribeAudio";
+
+const spin = keyframes`
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+`;
+
+const recordBlink = keyframes`
+  0%, 50% { opacity: 1; transform: scale(1); }
+  25%, 75% { opacity: 0.7; transform: scale(1.05); }
+`;
+
+type Props = {
+  onStartOrStop: () => void;
+  onResume: () => void;
+  onPause: () => void;
+  onCancel: () => void;
+  onUpload: () => void;
+};
+
+const RecordingToolbar = ({
+  onStartOrStop,
+  onResume,
+  onPause,
+  onCancel,
+  onUpload,
+}: Props) => {
+  const isRecording = useAppSelector(selectIsRecording);
+  const isPaused = useAppSelector(selectIsPaused);
+  const isProcessing = useAppSelector(selectTranscribeAudioLoading);
+
+  const iconSx = {
+    fontSize: 32,
+    transition: "all 0.2s ease",
+  };
+  const disabledSx = { opacity: 0.3, cursor: "not-allowed" };
+  const canUpload = !isRecording && !isProcessing;
+
+  return (
+    <Stack
+      direction="row"
+      justifyContent="center"
+      alignItems="center"
+      spacing={1}
+    >
+      {isProcessing ? (
+        <Box
+          component="span"
+          sx={{
+            display: "inline-flex",
+            width: 40,
+            height: 40,
+            border: "3px solid",
+            borderColor: "primary.main",
+            borderTopColor: "transparent",
+            borderRadius: "50%",
+            animation: `${spin} 1s linear infinite`,
+          }}
+        />
+      ) : (
+        <IconButton
+          onClick={onStartOrStop}
+          disabled={isProcessing}
+          sx={{
+            color: isRecording ? "error.main" : "grey.500",
+            ...(isRecording &&
+              !isPaused && {
+                animation: `${recordBlink} 1s infinite`,
+              }),
+            "&:hover:not(:disabled)": {
+              color: isRecording ? "error.dark" : "error.light",
+            },
+            ...iconSx,
+          }}
+          title={isRecording ? "Stop Recording" : "Start Recording"}
+        >
+          <FiberManualRecord sx={{ fontSize: 36 }} />
+        </IconButton>
+      )}
+
+      <IconButton
+        onClick={isPaused && !isProcessing ? onResume : undefined}
+        disabled={isProcessing || !isRecording || !isPaused}
+        sx={{
+          color: isPaused ? "success.main" : "grey.500",
+          "&:hover:not(:disabled)": { color: "success.light" },
+          ...iconSx,
+          ...(isProcessing || !isRecording || !isPaused ? disabledSx : {}),
+        }}
+        title="Resume Recording"
+      >
+        <PlayArrow sx={{ fontSize: 32 }} />
+      </IconButton>
+
+      <IconButton
+        onClick={
+          isRecording && !isPaused && !isProcessing ? onPause : undefined
+        }
+        disabled={isProcessing || !isRecording || isPaused}
+        sx={{
+          color: isRecording && !isPaused ? "warning.main" : "grey.500",
+          "&:hover:not(:disabled)": { color: "warning.light" },
+          ...iconSx,
+          ...(isProcessing || !isRecording || isPaused ? disabledSx : {}),
+        }}
+        title="Pause Recording"
+      >
+        <Pause sx={{ fontSize: 32 }} />
+      </IconButton>
+
+      <IconButton
+        onClick={isRecording && !isProcessing ? onCancel : undefined}
+        disabled={isProcessing || !isRecording}
+        sx={{
+          color: isRecording ? "error.main" : "grey.500",
+          "&:hover:not(:disabled)": { color: "error.light" },
+          ...iconSx,
+          ...(isProcessing || !isRecording ? disabledSx : {}),
+        }}
+        title="Cancel Recording"
+      >
+        <Cancel sx={{ fontSize: 32 }} />
+      </IconButton>
+
+      <IconButton
+        onClick={canUpload ? onUpload : undefined}
+        disabled={!canUpload}
+        sx={{
+          color: canUpload ? "primary.main" : "grey.500",
+          "&:hover:not(:disabled)": { color: "primary.light" },
+          ...iconSx,
+          ...(!canUpload ? disabledSx : {}),
+        }}
+        title="Upload Audio"
+      >
+        <Upload sx={{ fontSize: 32 }} />
+      </IconButton>
+    </Stack>
+  );
+};
+
+export default RecordingToolbar;

--- a/src/components/RecordingControls/index.tsx
+++ b/src/components/RecordingControls/index.tsx
@@ -1,158 +1,98 @@
-import { useState, useRef } from "react";
-import { Box, IconButton, Stack, Button, Alert } from "@mui/material";
-import {
-  FiberManualRecord,
-  PlayArrow,
-  Pause,
-  Cancel,
-  Refresh,
-  Download,
-  Upload,
-  Mic,
-} from "@mui/icons-material";
-import { keyframes } from "@emotion/react";
-
-const spin = keyframes`
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
-`;
+import { Stack } from "@mui/material";
+import { useCallback, useRef, useState } from "react";
 import HookWrapper from "./HookWrapper";
 import RecordingTimer from "./RecordingTimer";
-import { getApiUrl, API_ENDPOINTS } from "../../utils/apiConfig";
+import RecordingToolbar from "./RecordingToolbar";
+import PendingAudioBanner from "./PendingAudioBanner";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import { selectApiKey } from "../../features/settings/slice/selectors";
+import {
+  PendingSource,
+  recordingActions,
+  type PendingSource as PendingSourceType,
+} from "../../features/recording/slice/reducers";
+import {
+  selectIsPaused,
+  selectIsRecording,
+  selectPendingFileName,
+  selectPendingSource,
+} from "../../features/recording/slice/selectors";
+import { transcriptionActions } from "../../features/transcription/slice/reducers";
+import { transcribeAudio } from "../../features/transcription/slice/command/transcribeAudio";
 
-const recordBlink = keyframes`
-  0%, 50% { opacity: 1; transform: scale(1); }
-  25%, 75% { opacity: 0.7; transform: scale(1.05); }
-`;
+const RecordingControls = () => {
+  const dispatch = useAppDispatch();
+  const apiKey = useAppSelector(selectApiKey);
+  const isRecording = useAppSelector(selectIsRecording);
+  const isPaused = useAppSelector(selectIsPaused);
+  const pendingSource = useAppSelector(selectPendingSource);
+  const pendingFileName = useAppSelector(selectPendingFileName);
 
-const PendingSource = {
-  Upload: "upload",
-  Recording: "recording",
-} as const;
-
-type PendingSource = (typeof PendingSource)[keyof typeof PendingSource];
-
-type Props = {
-  setTranscription: (newTranscription: string) => void;
-  setError: (error: string) => void;
-  setIsCopied: React.Dispatch<React.SetStateAction<boolean>>;
-  apiKey: string;
-  model: string;
-};
-
-const RecordingControls = ({
-  setTranscription,
-  setError,
-  setIsCopied,
-  apiKey,
-  model,
-}: Props) => {
-  const [isRecording, setIsRecording] = useState(false);
-  const [isPaused, setIsPaused] = useState(false);
-  const [isProcessing, setIsProcessing] = useState(false);
   const [pendingAudio, setPendingAudio] = useState<Blob | null>(null);
-  const [pendingSource, setPendingSource] = useState<PendingSource | null>(
-    null
-  );
-  const [pendingFileName, setPendingFileName] = useState<string>("");
-  const [hasFailedAttempt, setHasFailedAttempt] = useState(false);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
   const streamRef = useRef<MediaStream | null>(null);
-  const shouldProcessRef = useRef<boolean>(false);
+  const shouldProcessRef = useRef(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
-  const onTranscriptionComplete = async (newTranscription: string) => {
-    setTranscription(newTranscription);
-    try {
-      await navigator.clipboard.writeText(newTranscription);
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to auto-copy to clipboard:", err);
-    }
-  };
-
-  const stopStream = () => {
+  const stopStream = useCallback(() => {
     if (streamRef.current) {
       streamRef.current.getTracks().forEach((track) => track.stop());
       streamRef.current = null;
     }
-  };
+  }, []);
 
-  const clearPendingAudio = () => {
+  const clearPending = useCallback(() => {
     setPendingAudio(null);
-    setPendingSource(null);
-    setPendingFileName("");
-    setHasFailedAttempt(false);
-  };
+    dispatch(recordingActions.clearPending());
+  }, [dispatch]);
 
-  const preservePendingAudio = (
-    audioBlob: Blob,
-    fileName: string,
-    source: PendingSource
-  ) => {
-    setPendingAudio(audioBlob);
-    setPendingFileName(fileName);
-    setPendingSource(source);
-    setHasFailedAttempt(true);
-  };
+  const preservePending = useCallback(
+    (audioBlob: Blob, fileName: string, source: PendingSourceType) => {
+      setPendingAudio(audioBlob);
+      dispatch(recordingActions.preservePending({ fileName, source }));
+    },
+    [dispatch]
+  );
 
-  const sendAudioToServer = async (
-    audioBlob: Blob,
-    fileName = "recording.webm",
-    source: PendingSource = PendingSource.Recording
-  ) => {
-    if (!apiKey.trim()) {
-      setError("Please enter your OpenAI API key before recording.");
-      preservePendingAudio(audioBlob, fileName, source);
-      return;
-    }
-
-    setIsProcessing(true);
-    setError("");
-
-    try {
-      const formData = new FormData();
-      formData.append("audio", audioBlob, fileName);
-      formData.append("apiKey", apiKey);
-      formData.append("model", model);
-
-      const response = await fetch(getApiUrl(API_ENDPOINTS.TRANSCRIBE), {
-        method: "POST",
-        body: formData,
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+  const sendAudioToServer = useCallback(
+    async (
+      audioBlob: Blob,
+      fileName = "recording.webm",
+      source: PendingSourceType = PendingSource.Recording
+    ) => {
+      if (!apiKey.trim()) {
+        dispatch(
+          transcriptionActions.setError(
+            "Please enter your OpenAI API key before recording."
+          )
+        );
+        preservePending(audioBlob, fileName, source);
+        return;
       }
 
-      const result = await response.json();
-
-      if (result.success) {
-        onTranscriptionComplete(result.transcription);
-        clearPendingAudio();
-      } else {
-        setError(result.error || "Transcription failed");
-        preservePendingAudio(audioBlob, fileName, source);
+      try {
+        await transcribeAudio({ audioBlob, fileName }).promise;
+        clearPending();
+      } catch {
+        preservePending(audioBlob, fileName, source);
       }
-    } catch (err) {
-      setError("Failed to transcribe audio. Please try again.");
-      console.error("Transcription error:", err);
-      preservePendingAudio(audioBlob, fileName, source);
-    } finally {
-      setIsProcessing(false);
-    }
-  };
+    },
+    [apiKey, clearPending, dispatch, preservePending]
+  );
 
-  const startRecording = async () => {
+  const startRecording = useCallback(async () => {
     if (!apiKey.trim()) {
-      setError("Please enter your OpenAI API key before recording.");
+      dispatch(
+        transcriptionActions.setError(
+          "Please enter your OpenAI API key before recording."
+        )
+      );
       return;
     }
 
     try {
-      setError("");
+      dispatch(transcriptionActions.setError(""));
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
 
@@ -185,7 +125,7 @@ const RecordingControls = ({
       };
 
       mediaRecorder.start();
-      setIsRecording(true);
+      dispatch(recordingActions.recordingStarted());
 
       if (document.hidden) {
         if ("Notification" in window && Notification.permission === "granted") {
@@ -196,47 +136,80 @@ const RecordingControls = ({
         }
       }
     } catch (err) {
-      setError(
-        `Failed to start recording. Please check microphone permissions. ${err}`
+      dispatch(
+        transcriptionActions.setError(
+          `Failed to start recording. Please check microphone permissions. ${err}`
+        )
       );
       console.error("Recording error:", err);
     }
-  };
+  }, [apiKey, dispatch, sendAudioToServer, stopStream]);
 
-  const pauseRecording = () => {
+  const pauseRecording = useCallback(() => {
     if (mediaRecorderRef.current && isRecording && !isPaused) {
       mediaRecorderRef.current.pause();
-      setIsPaused(true);
+      dispatch(recordingActions.recordingPaused());
     }
-  };
+  }, [dispatch, isPaused, isRecording]);
 
-  const resumeRecording = () => {
+  const resumeRecording = useCallback(() => {
     if (mediaRecorderRef.current && isRecording && isPaused) {
       mediaRecorderRef.current.resume();
-      setIsPaused(false);
+      dispatch(recordingActions.recordingResumed());
     }
-  };
+  }, [dispatch, isPaused, isRecording]);
 
-  const stopRecording = () => {
+  const stopRecording = useCallback(() => {
     if (mediaRecorderRef.current && isRecording) {
       shouldProcessRef.current = true;
       mediaRecorderRef.current.stop();
-      setIsRecording(false);
-      setIsPaused(false);
+      dispatch(recordingActions.recordingStopped());
     }
-  };
+  }, [dispatch, isRecording]);
 
-  const cancelRecording = () => {
+  const cancelRecording = useCallback(() => {
     if (mediaRecorderRef.current && isRecording) {
       shouldProcessRef.current = false;
       mediaRecorderRef.current.stop();
-      setIsRecording(false);
-      setIsPaused(false);
+      dispatch(recordingActions.recordingCancelled());
       audioChunksRef.current = [];
     }
-  };
+  }, [dispatch, isRecording]);
 
-  const transcribePendingAudio = async () => {
+  const handleStartOrStop = useCallback(() => {
+    if (isRecording) {
+      stopRecording();
+    } else {
+      void startRecording();
+    }
+  }, [isRecording, startRecording, stopRecording]);
+
+  const openFilePicker = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileUpload = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) {
+        return;
+      }
+      setPendingAudio(file);
+      dispatch(recordingActions.setPendingUpload({ fileName: file.name }));
+      dispatch(transcriptionActions.setError(""));
+    },
+    [dispatch]
+  );
+
+  const handleDismissPending = useCallback(() => {
+    clearPending();
+    dispatch(transcriptionActions.setError(""));
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }, [clearPending, dispatch]);
+
+  const transcribePendingAudio = useCallback(async () => {
     if (pendingAudio) {
       await sendAudioToServer(
         pendingAudio,
@@ -244,61 +217,26 @@ const RecordingControls = ({
         pendingSource ?? PendingSource.Recording
       );
     }
-  };
+  }, [pendingAudio, pendingFileName, pendingSource, sendAudioToServer]);
 
-  const downloadRecording = () => {
-    if (pendingAudio) {
-      const url = URL.createObjectURL(pendingAudio);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download =
-        pendingFileName || `recording-${new Date().toISOString()}.webm`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    }
-  };
-
-  const dismissPendingAudio = () => {
-    clearPendingAudio();
-    setError("");
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-  };
-
-  const openFilePicker = () => {
-    fileInputRef.current?.click();
-  };
-
-  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) {
+  const downloadRecording = useCallback(() => {
+    if (!pendingAudio) {
       return;
     }
-
-    setPendingAudio(file);
-    setPendingSource(PendingSource.Upload);
-    setPendingFileName(file.name);
-    setHasFailedAttempt(false);
-    setError("");
-  };
-
-  const iconSx = {
-    fontSize: 32,
-    transition: "all 0.2s ease",
-  };
-  const disabledSx = { opacity: 0.3, cursor: "not-allowed" };
-  const canUpload = !isRecording && !isProcessing;
-  const isUploadPending =
-    pendingSource === PendingSource.Upload && !hasFailedAttempt;
+    const url = URL.createObjectURL(pendingAudio);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download =
+      pendingFileName || `recording-${new Date().toISOString()}.webm`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, [pendingAudio, pendingFileName]);
 
   return (
     <>
       <HookWrapper
-        isRecording={isRecording}
-        isPaused={isPaused}
         startRecording={startRecording}
         stopRecording={stopRecording}
         pauseRecording={pauseRecording}
@@ -326,145 +264,26 @@ const RecordingControls = ({
           bgcolor: "action.hover",
         }}
       >
-        <Stack
-          direction="row"
-          justifyContent="center"
-          alignItems="center"
-          spacing={1}
-        >
-          {isProcessing ? (
-            <Box
-              component="span"
-              sx={{
-                display: "inline-flex",
-                width: 40,
-                height: 40,
-                border: "3px solid",
-                borderColor: "primary.main",
-                borderTopColor: "transparent",
-                borderRadius: "50%",
-                animation: `${spin} 1s linear infinite`,
-              }}
-            />
-          ) : (
-            <IconButton
-              onClick={isRecording ? stopRecording : startRecording}
-              disabled={isProcessing}
-              sx={{
-                color: isRecording ? "error.main" : "grey.500",
-                ...(isRecording &&
-                  !isPaused && {
-                    animation: `${recordBlink} 1s infinite`,
-                  }),
-                "&:hover:not(:disabled)": {
-                  color: isRecording ? "error.dark" : "error.light",
-                },
-                ...iconSx,
-              }}
-              title={isRecording ? "Stop Recording" : "Start Recording"}
-            >
-              <FiberManualRecord sx={{ fontSize: 36 }} />
-            </IconButton>
-          )}
-
-          <IconButton
-            onClick={isPaused && !isProcessing ? resumeRecording : undefined}
-            disabled={isProcessing || !isRecording || !isPaused}
-            sx={{
-              color: isPaused ? "success.main" : "grey.500",
-              "&:hover:not(:disabled)": { color: "success.light" },
-              ...iconSx,
-              ...(isProcessing || !isRecording || !isPaused ? disabledSx : {}),
-            }}
-            title="Resume Recording"
-          >
-            <PlayArrow sx={{ fontSize: 32 }} />
-          </IconButton>
-
-          <IconButton
-            onClick={
-              isRecording && !isPaused && !isProcessing
-                ? pauseRecording
-                : undefined
-            }
-            disabled={isProcessing || !isRecording || isPaused}
-            sx={{
-              color: isRecording && !isPaused ? "warning.main" : "grey.500",
-              "&:hover:not(:disabled)": { color: "warning.light" },
-              ...iconSx,
-              ...(isProcessing || !isRecording || isPaused ? disabledSx : {}),
-            }}
-            title="Pause Recording"
-          >
-            <Pause sx={{ fontSize: 32 }} />
-          </IconButton>
-
-          <IconButton
-            onClick={isRecording && !isProcessing ? cancelRecording : undefined}
-            disabled={isProcessing || !isRecording}
-            sx={{
-              color: isRecording ? "error.main" : "grey.500",
-              "&:hover:not(:disabled)": { color: "error.light" },
-              ...iconSx,
-              ...(isProcessing || !isRecording ? disabledSx : {}),
-            }}
-            title="Cancel Recording"
-          >
-            <Cancel sx={{ fontSize: 32 }} />
-          </IconButton>
-
-          <IconButton
-            onClick={canUpload ? openFilePicker : undefined}
-            disabled={!canUpload}
-            sx={{
-              color: canUpload ? "primary.main" : "grey.500",
-              "&:hover:not(:disabled)": { color: "primary.light" },
-              ...iconSx,
-              ...(!canUpload ? disabledSx : {}),
-            }}
-            title="Upload Audio"
-          >
-            <Upload sx={{ fontSize: 32 }} />
-          </IconButton>
-        </Stack>
+        <RecordingToolbar
+          onStartOrStop={handleStartOrStop}
+          onResume={resumeRecording}
+          onPause={pauseRecording}
+          onCancel={cancelRecording}
+          onUpload={openFilePicker}
+        />
 
         <Stack direction="row" justifyContent="center">
-          <RecordingTimer isRecording={isRecording} isPaused={isPaused} />
+          <RecordingTimer />
         </Stack>
 
         {pendingAudio && (
-          <Alert
-            severity={isUploadPending ? "info" : "warning"}
-            onClose={dismissPendingAudio}
-            sx={{ mt: 2 }}
-          >
-            {isUploadPending
-              ? `Audio ready: ${pendingFileName || "uploaded file"}`
-              : pendingSource === PendingSource.Upload
-                ? `Transcription failed for ${pendingFileName || "uploaded file"}. You can retry or download.`
-                : "Recording saved! The transcription request failed, but your recording is preserved."}
-            <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
-              <Button
-                variant="contained"
-                size="small"
-                startIcon={isUploadPending ? <Mic /> : <Refresh />}
-                onClick={transcribePendingAudio}
-                disabled={isProcessing}
-                sx={{ flex: 1 }}
-              >
-                {isUploadPending ? "Transcribe" : "Retry"}
-              </Button>
-              <Button
-                variant="outlined"
-                size="small"
-                startIcon={<Download />}
-                onClick={downloadRecording}
-                sx={{ flex: 1 }}
-              >
-                Download
-              </Button>
-            </Stack>
-          </Alert>
+          <PendingAudioBanner
+            onDismiss={handleDismissPending}
+            onTranscribe={() => {
+              void transcribePendingAudio();
+            }}
+            onDownload={downloadRecording}
+          />
         )}
       </Stack>
     </>

--- a/src/components/Settings/ApiKeySection.tsx
+++ b/src/components/Settings/ApiKeySection.tsx
@@ -7,31 +7,31 @@ import {
   Typography,
   Link,
 } from "@mui/material";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import { settingsActions } from "../../features/settings/slice/reducers";
+import { selectApiKey } from "../../features/settings/slice/selectors";
 
 type Props = {
-  setApiKey: (apiKey: string) => void;
   onSubmitted?: () => void;
 };
 
-const ApiKeySection = ({ setApiKey, onSubmitted }: Props) => {
-  const [isSubmitted, setIsSubmitted] = useState(false);
+const ApiKeySection = ({ onSubmitted }: Props) => {
+  const dispatch = useAppDispatch();
+  const apiKey = useAppSelector(selectApiKey);
+  const isSubmitted = Boolean(apiKey.trim());
   const [tempApiKey, setTempApiKey] = useState("");
 
   const handleSubmit = () => {
     if (tempApiKey.trim()) {
-      setApiKey(tempApiKey);
-      setIsSubmitted(true);
+      dispatch(settingsActions.setApiKey(tempApiKey));
       setTempApiKey("");
-      if (onSubmitted) {
-        onSubmitted();
-      }
+      onSubmitted?.();
     }
   };
 
   const handleReenter = () => {
-    setIsSubmitted(false);
     setTempApiKey("");
-    setApiKey("");
+    dispatch(settingsActions.setApiKey(""));
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
@@ -68,7 +68,9 @@ const ApiKeySection = ({ setApiKey, onSubmitted }: Props) => {
           </Button>
         </Box>
       ) : (
-        <Box sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap" }}>
+        <Box
+          sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap" }}
+        >
           <Button variant="outlined" onClick={handleReenter}>
             Re-enter API Key
           </Button>

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -20,14 +20,13 @@ import {
   TRANSCRIPTION_MODEL_DESCRIPTIONS,
   type TranscriptionModelId,
 } from "./transcriptionModels";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import { settingsActions } from "../../features/settings/slice/reducers";
+import { selectModel } from "../../features/settings/slice/selectors";
 
-type Props = {
-  setApiKey: (apiKey: string) => void;
-  model: TranscriptionModelId;
-  setModel: (model: TranscriptionModelId) => void;
-};
-
-const Settings = ({ setApiKey, model, setModel }: Props) => {
+const Settings = () => {
+  const dispatch = useAppDispatch();
+  const model = useAppSelector(selectModel);
   const [expanded, setExpanded] = useState<string | false>(false);
 
   const handleChange =
@@ -111,7 +110,11 @@ const Settings = ({ setApiKey, model, setModel }: Props) => {
                     value={model}
                     label="Transcription model"
                     onChange={(e) =>
-                      setModel(e.target.value as TranscriptionModelId)
+                      dispatch(
+                        settingsActions.setModel(
+                          e.target.value as TranscriptionModelId
+                        )
+                      )
                     }
                   >
                     {TRANSCRIPTION_MODEL_IDS.map((id) => (
@@ -129,10 +132,7 @@ const Settings = ({ setApiKey, model, setModel }: Props) => {
                   {TRANSCRIPTION_MODEL_DESCRIPTIONS[model]}
                 </Typography>
               </Box>
-              <ApiKeySection
-                setApiKey={setApiKey}
-                onSubmitted={() => setExpanded(false)}
-              />
+              <ApiKeySection onSubmitted={() => setExpanded(false)} />
             </Stack>
           </AccordionDetails>
         </Accordion>

--- a/src/components/TranscriptionActions.tsx
+++ b/src/components/TranscriptionActions.tsx
@@ -1,24 +1,24 @@
 import { Button, IconButton, Box } from "@mui/material";
 import { Check, ContentCopy } from "@mui/icons-material";
+import { useAppDispatch, useAppSelector } from "../store/hooks";
+import { transcriptionActions } from "../features/transcription/slice/reducers";
+import {
+  selectIsCopied,
+  selectTranscriptionText,
+} from "../features/transcription/slice/selectors";
 
-type Props = {
-  transcription: string;
-  onClear: () => void;
-  isCopied: boolean;
-  setIsCopied: React.Dispatch<React.SetStateAction<boolean>>;
-};
+const TranscriptionActions = () => {
+  const dispatch = useAppDispatch();
+  const transcription = useAppSelector(selectTranscriptionText);
+  const isCopied = useAppSelector(selectIsCopied);
 
-const TranscriptionActions = ({
-  transcription,
-  onClear,
-  isCopied,
-  setIsCopied,
-}: Props) => {
   const copyToClipboard = async () => {
     try {
       await navigator.clipboard.writeText(transcription);
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), 2000);
+      dispatch(transcriptionActions.setIsCopied(true));
+      setTimeout(() => {
+        dispatch(transcriptionActions.setIsCopied(false));
+      }, 2000);
     } catch (err) {
       console.error("Failed to copy to clipboard:", err);
     }
@@ -33,7 +33,10 @@ const TranscriptionActions = ({
       >
         {isCopied ? <Check /> : <ContentCopy />}
       </IconButton>
-      <Button variant="outlined" onClick={onClear}>
+      <Button
+        variant="outlined"
+        onClick={() => dispatch(transcriptionActions.clearTranscription())}
+      >
         Clear
       </Button>
     </Box>

--- a/src/components/TranscriptionEditor.tsx
+++ b/src/components/TranscriptionEditor.tsx
@@ -1,23 +1,25 @@
 import { TextField } from "@mui/material";
+import { useAppDispatch, useAppSelector } from "../store/hooks";
+import { transcriptionActions } from "../features/transcription/slice/reducers";
+import { selectTranscriptionText } from "../features/transcription/slice/selectors";
 
 type Props = {
-  value: string;
-  onChange: (value: string) => void;
   placeholder?: string;
 };
 
 const TranscriptionEditor = ({
-  value,
-  onChange,
   placeholder = "Transcription will appear here...",
 }: Props) => {
+  const dispatch = useAppDispatch();
+  const value = useAppSelector(selectTranscriptionText);
+
   return (
     <TextField
       multiline
       fullWidth
       minRows={4}
       value={value}
-      onChange={(e) => onChange(e.target.value)}
+      onChange={(e) => dispatch(transcriptionActions.setText(e.target.value))}
       placeholder={placeholder}
       variant="outlined"
       sx={{

--- a/src/components/TranscriptionHistory.tsx
+++ b/src/components/TranscriptionHistory.tsx
@@ -11,18 +11,14 @@ import { Check, ContentCopy, Delete } from "@mui/icons-material";
 import {
   MIN_WORDS,
   STORED_TRANSCRIPTIONS,
-  TranscriptionRecord,
 } from "../utils/transcriptionStorage";
+import { useAppDispatch, useAppSelector } from "../store/hooks";
+import { transcriptionActions } from "../features/transcription/slice/reducers";
+import { selectTranscriptionHistory } from "../features/transcription/slice/selectors";
 
-type Props = {
-  transcriptions: TranscriptionRecord[];
-  onDeleteTranscription: (id: string) => void;
-};
-
-const TranscriptionHistory = ({
-  transcriptions,
-  onDeleteTranscription,
-}: Props) => {
+const TranscriptionHistory = () => {
+  const dispatch = useAppDispatch();
+  const transcriptions = useAppSelector(selectTranscriptionHistory);
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
   const copyToClipboard = async (text: string, id: string) => {
@@ -56,7 +52,12 @@ const TranscriptionHistory = ({
 
   return (
     <Box>
-      <Typography variant="subtitle1" fontWeight={600} textAlign="center" sx={{ mb: 1 }}>
+      <Typography
+        variant="subtitle1"
+        fontWeight={600}
+        textAlign="center"
+        sx={{ mb: 1 }}
+      >
         Previous {STORED_TRANSCRIPTIONS} Transcriptions (minimum {MIN_WORDS}{" "}
         words)
       </Typography>
@@ -113,7 +114,11 @@ const TranscriptionHistory = ({
                 </IconButton>
                 <IconButton
                   size="small"
-                  onClick={() => onDeleteTranscription(transcription.id)}
+                  onClick={() =>
+                    dispatch(
+                      transcriptionActions.removeTranscription(transcription.id)
+                    )
+                  }
                   title="Delete transcription"
                   color="error"
                 >

--- a/src/features/recording/slice/reducers.ts
+++ b/src/features/recording/slice/reducers.ts
@@ -1,0 +1,83 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+export const PendingSource = {
+  Upload: "upload",
+  Recording: "recording",
+} as const;
+
+export type PendingSource =
+  (typeof PendingSource)[keyof typeof PendingSource];
+
+export type RecordingState = {
+  isRecording: boolean;
+  isPaused: boolean;
+  pendingSource: PendingSource | null;
+  pendingFileName: string;
+  hasFailedAttempt: boolean;
+};
+
+type PreservePendingPayload = {
+  fileName: string;
+  source: PendingSource;
+};
+
+type SetPendingUploadPayload = {
+  fileName: string;
+};
+
+const initialState: RecordingState = {
+  isRecording: false,
+  isPaused: false,
+  pendingSource: null,
+  pendingFileName: "",
+  hasFailedAttempt: false,
+};
+
+const recordingSlice = createSlice({
+  name: "recording",
+  initialState,
+  reducers: {
+    recordingStarted: (state) => {
+      state.isRecording = true;
+      state.isPaused = false;
+    },
+    recordingStopped: (state) => {
+      state.isRecording = false;
+      state.isPaused = false;
+    },
+    recordingPaused: (state) => {
+      state.isPaused = true;
+    },
+    recordingResumed: (state) => {
+      state.isPaused = false;
+    },
+    recordingCancelled: (state) => {
+      state.isRecording = false;
+      state.isPaused = false;
+    },
+    setPendingUpload: (
+      state,
+      action: PayloadAction<SetPendingUploadPayload>
+    ) => {
+      state.pendingSource = PendingSource.Upload;
+      state.pendingFileName = action.payload.fileName;
+      state.hasFailedAttempt = false;
+    },
+    preservePending: (
+      state,
+      action: PayloadAction<PreservePendingPayload>
+    ) => {
+      state.pendingFileName = action.payload.fileName;
+      state.pendingSource = action.payload.source;
+      state.hasFailedAttempt = true;
+    },
+    clearPending: (state) => {
+      state.pendingSource = null;
+      state.pendingFileName = "";
+      state.hasFailedAttempt = false;
+    },
+  },
+});
+
+export const recordingActions = recordingSlice.actions;
+export const recordingReducer = recordingSlice.reducer;

--- a/src/features/recording/slice/selectors.ts
+++ b/src/features/recording/slice/selectors.ts
@@ -1,0 +1,15 @@
+import type { RootState } from "../../../store";
+import { PendingSource } from "./reducers";
+
+export const selectIsRecording = (state: RootState) =>
+  state.recording.isRecording;
+export const selectIsPaused = (state: RootState) => state.recording.isPaused;
+export const selectPendingSource = (state: RootState) =>
+  state.recording.pendingSource;
+export const selectPendingFileName = (state: RootState) =>
+  state.recording.pendingFileName;
+export const selectHasFailedAttempt = (state: RootState) =>
+  state.recording.hasFailedAttempt;
+export const selectIsUploadPending = (state: RootState) =>
+  state.recording.pendingSource === PendingSource.Upload &&
+  !state.recording.hasFailedAttempt;

--- a/src/features/settings/slice/reducers.ts
+++ b/src/features/settings/slice/reducers.ts
@@ -1,0 +1,28 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { TranscriptionModelId } from "../../../components/Settings/transcriptionModels";
+
+export type SettingsState = {
+  apiKey: string;
+  model: TranscriptionModelId;
+};
+
+const initialState: SettingsState = {
+  apiKey: "",
+  model: "whisper-1",
+};
+
+const settingsSlice = createSlice({
+  name: "settings",
+  initialState,
+  reducers: {
+    setApiKey: (state, action: PayloadAction<string>) => {
+      state.apiKey = action.payload;
+    },
+    setModel: (state, action: PayloadAction<TranscriptionModelId>) => {
+      state.model = action.payload;
+    },
+  },
+});
+
+export const settingsActions = settingsSlice.actions;
+export const settingsReducer = settingsSlice.reducer;

--- a/src/features/settings/slice/selectors.ts
+++ b/src/features/settings/slice/selectors.ts
@@ -1,0 +1,4 @@
+import type { RootState } from "../../../store";
+
+export const selectApiKey = (state: RootState) => state.settings.apiKey;
+export const selectModel = (state: RootState) => state.settings.model;

--- a/src/features/transcription/slice/command/transcribeAudio.ts
+++ b/src/features/transcription/slice/command/transcribeAudio.ts
@@ -1,0 +1,84 @@
+import { createAsyncAction } from "async-selector-kit";
+import type { RootState } from "../../../../store";
+import { getApiUrl, API_ENDPOINTS } from "../../../../utils/apiConfig";
+import { selectApiKey, selectModel } from "../../../settings/slice/selectors";
+import { transcriptionActions } from "../reducers";
+
+type Params = {
+  audioBlob: Blob;
+  fileName: string;
+};
+
+type TranscribeResponse = {
+  success: boolean;
+  transcription?: string;
+  error?: string;
+};
+
+export const [
+  transcribeAudio,
+  selectTranscribeAudioLoading,
+  selectTranscribeAudioError,
+] = createAsyncAction<RootState, void, Params, string, string>(
+  {
+    id: "transcribeAudio",
+    async:
+      (store, _status, apiKey, model) =>
+      async ({ audioBlob, fileName }) => {
+        store.dispatch(transcriptionActions.setError(""));
+
+        const formData = new FormData();
+        formData.append("audio", audioBlob, fileName);
+        formData.append("apiKey", apiKey);
+        formData.append("model", model);
+
+        let response: Response;
+        try {
+          response = await fetch(getApiUrl(API_ENDPOINTS.TRANSCRIBE), {
+            method: "POST",
+            body: formData,
+          });
+        } catch (err) {
+          store.dispatch(
+            transcriptionActions.setError(
+              "Failed to transcribe audio. Please try again."
+            )
+          );
+          console.error("Transcription error:", err);
+          throw err;
+        }
+
+        if (!response.ok) {
+          store.dispatch(
+            transcriptionActions.setError(
+              "Failed to transcribe audio. Please try again."
+            )
+          );
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const result = (await response.json()) as TranscribeResponse;
+
+        if (!result.success || !result.transcription) {
+          const message = result.error || "Transcription failed";
+          store.dispatch(transcriptionActions.setError(message));
+          throw new Error(message);
+        }
+
+        store.dispatch(
+          transcriptionActions.addTranscription(result.transcription)
+        );
+
+        try {
+          await navigator.clipboard.writeText(result.transcription);
+          store.dispatch(transcriptionActions.setIsCopied(true));
+          setTimeout(() => {
+            store.dispatch(transcriptionActions.setIsCopied(false));
+          }, 2000);
+        } catch (err) {
+          console.error("Failed to auto-copy to clipboard:", err);
+        }
+      },
+  },
+  [selectApiKey, selectModel]
+);

--- a/src/features/transcription/slice/reducers.ts
+++ b/src/features/transcription/slice/reducers.ts
@@ -1,0 +1,58 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import {
+  deleteTranscription,
+  getTranscriptions,
+  saveTranscription,
+  type TranscriptionRecord,
+} from "../../../utils/transcriptionStorage";
+
+export type TranscriptionState = {
+  text: string;
+  history: TranscriptionRecord[];
+  error: string;
+  isCopied: boolean;
+};
+
+const initialState: TranscriptionState = {
+  text: "",
+  history: [],
+  error: "",
+  isCopied: false,
+};
+
+const transcriptionSlice = createSlice({
+  name: "transcription",
+  initialState,
+  reducers: {
+    setText: (state, action: PayloadAction<string>) => {
+      state.text = action.payload;
+    },
+    clearTranscription: (state) => {
+      state.text = "";
+      state.error = "";
+    },
+    setError: (state, action: PayloadAction<string>) => {
+      state.error = action.payload;
+    },
+    setIsCopied: (state, action: PayloadAction<boolean>) => {
+      state.isCopied = action.payload;
+    },
+    hydrateHistory: (state) => {
+      state.history = getTranscriptions();
+    },
+    addTranscription: (state, action: PayloadAction<string>) => {
+      state.text = action.payload;
+      const savedRecord = saveTranscription(action.payload);
+      if (savedRecord) {
+        state.history = [savedRecord, ...state.history];
+      }
+    },
+    removeTranscription: (state, action: PayloadAction<string>) => {
+      deleteTranscription(action.payload);
+      state.history = state.history.filter((t) => t.id !== action.payload);
+    },
+  },
+});
+
+export const transcriptionActions = transcriptionSlice.actions;
+export const transcriptionReducer = transcriptionSlice.reducer;

--- a/src/features/transcription/slice/selectors.ts
+++ b/src/features/transcription/slice/selectors.ts
@@ -1,0 +1,10 @@
+import type { RootState } from "../../../store";
+
+export const selectTranscriptionText = (state: RootState) =>
+  state.transcription.text;
+export const selectTranscriptionHistory = (state: RootState) =>
+  state.transcription.history;
+export const selectTranscriptionError = (state: RootState) =>
+  state.transcription.error;
+export const selectIsCopied = (state: RootState) =>
+  state.transcription.isCopied;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,17 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import ThemeWrapper from './components/ThemeWrapper'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { Provider } from "react-redux";
+import "./index.css";
+import ThemeWrapper from "./components/ThemeWrapper";
+import App from "./App.tsx";
+import { store } from "./store";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ThemeWrapper>
-      <App />
-    </ThemeWrapper>
+    <Provider store={store}>
+      <ThemeWrapper>
+        <App />
+      </ThemeWrapper>
+    </Provider>
   </StrictMode>
-)
+);

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,5 @@
+import { useDispatch, useSelector } from "react-redux";
+import type { AppDispatch, RootState } from "./index";
+
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
+export const useAppSelector = useSelector.withTypes<RootState>();

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,39 @@
+import { configureStore } from "@reduxjs/toolkit";
+import {
+  ACTION_FINISHED,
+  ACTION_STARTED,
+  createMiddleware,
+  createReducer,
+  PROMISE_REJECTED,
+  PROMISE_RESOLVED,
+  SUBSCRIPTION_UPDATED,
+} from "async-selector-kit";
+import { recordingReducer } from "../features/recording/slice/reducers";
+import { settingsReducer } from "../features/settings/slice/reducers";
+import { transcriptionReducer } from "../features/transcription/slice/reducers";
+
+const asyncSelectorSerializableIgnored = [
+  PROMISE_RESOLVED,
+  PROMISE_REJECTED,
+  ACTION_STARTED,
+  ACTION_FINISHED,
+  SUBSCRIPTION_UPDATED,
+] as const;
+
+export const store = configureStore({
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [...asyncSelectorSerializableIgnored],
+      },
+    }).concat(createMiddleware()),
+  reducer: {
+    settings: settingsReducer,
+    transcription: transcriptionReducer,
+    recording: recordingReducer,
+    AsyncSelector: createReducer(),
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## Changes

- Add Redux Toolkit store with typed hooks
- Add settings, transcription, and recording slices
- Transcribe via async-selector-kit createAsyncAction
- Split RecordingControls into toolbar and banner
- Remove App prop drilling for shared state